### PR TITLE
Make the DB_NAME option relative to the current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ micro-analytics
 Options are set via environment variables. These are the possible options for this adapter:
 
 ```sh
-DB_PATH    # set the location the database should be created in
+DB_NAME    # set the location the database should be created in
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
+const path = require('path')
 const flatfile = require('flat-file-db')
 const promisify = require('then-flat-file-db')
 const escapeRegexp = require('escape-regex')
 const Observable = require("zen-observable")
 
-const db = promisify(flatfile.sync(process.env.DB_NAME || 'views.db'))
+const db = promisify(flatfile.sync(path.resolve(process.cwd(), process.env.DB_NAME || 'views.db')))
 
 const keyRegex = (str) => {
   str = str.split('*').map( s => escapeRegexp(s)).join('*')

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ const flatfile = require('flat-file-db')
 const promisify = require('then-flat-file-db')
 const test = require('micro-analytics-cli/adapter-tests/unit-tests')
 
-const db = promisify(flatfile.sync(process.env.DB_NAME || 'views.db'))
+const db = promisify(flatfile.sync(path.resolve(process.cwd(), process.env.DB_NAME || 'views.db')))
 
 
 test({


### PR DESCRIPTION
This also defaults the `views.db` to be placed in the current working directory, because having it stored in 'node_modules/micro-analytics-cli' seems undesirable.